### PR TITLE
Moving hook_theme into .module

### DIFF
--- a/icon_browser.admin.inc
+++ b/icon_browser.admin.inc
@@ -52,19 +52,6 @@ function icon_browser_page() {
 }
 
 /**
- * Implements hook_theme().
- */
-function icon_browser_theme() {
-  return array(
-    'icon_browser_page' => array(
-      'variables' => array(
-        'icons' => array(),
-      ),
-    ),
-  );
-}
-
-/**
  * Form for filtering icons.
  *
  * @param array $form

--- a/icon_browser.module
+++ b/icon_browser.module
@@ -48,3 +48,16 @@ function icon_browser_load($icon_name) {
     'path' => icon_get_path($icon_name),
   );
 }
+
+/**
+ * Implements hook_theme().
+ */
+function icon_browser_theme() {
+  return array(
+    'icon_browser_page' => array(
+      'variables' => array(
+        'icons' => array(),
+      ),
+    ),
+  );
+}


### PR DESCRIPTION
Fixes: https://github.com/backdrop-contrib/icon_browser/issues/1

I don't know if this is the best fix, but it at least allows me to access the main config page that displays all the available icons.