### PR TITLE
Issue #15: Handle optional icon name in hook_icon_info().

### DIFF
--- a/icon_browser.admin.inc
+++ b/icon_browser.admin.inc
@@ -257,7 +257,7 @@ function icon_browser_icon_details($icon_key = '') {
       'provider' => 'module',
       'provider_detail' => t('@module (module)', ['@module' => $icon['module']]),
       'provider_key' => $key,
-      'name' => $icon['name'],
+      'name' => isset($icon['name']) ? $icon['name'] : $key,
       'fill' => substr($icon['name'], -5, 5) === '-fill',
     );
   }


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/icon_browser/issues/15.