### PR TITLE
Issue #15: Handle missing icon name coming from hook_icon_info().

### DIFF
--- a/icon_browser.admin.inc
+++ b/icon_browser.admin.inc
@@ -265,7 +265,7 @@ function icon_browser_icon_details($icon_key = '') {
       'provider' => 'module',
       'provider_detail' => t('@module (module)', ['@module' => $icon['module']]),
       'provider_key' => $key,
-      'name' => $icon['name'],
+      'name' => isset($icon['name']) ? $icon['name'] : $key,
     ) + icon_browser_get_icon_style($icon['name']);
   }
   // Icons provided by themes.


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/icon_browser/issues/15.